### PR TITLE
Extend references with new ShowSchemas type

### DIFF
--- a/datafusion/core/src/catalog_common/mod.rs
+++ b/datafusion/core/src/catalog_common/mod.rs
@@ -156,6 +156,8 @@ pub fn resolve_table_references(
                     | Statement::ShowColumns { .. }
                     | Statement::ShowTables { .. }
                     | Statement::ShowCollation { .. }
+                    | Statement::ShowSchemas { .. }
+                    | Statement::ShowDatabases { .. }
             );
             if requires_information_schema {
                 for s in INFORMATION_SCHEMA_TABLES {

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -285,6 +285,8 @@ impl SessionState {
             .build()
     }
 
+    /// Resolves a [`TableReference`] to a [`ResolvedTableReference`]
+    /// using the default catalog and schema.
     pub fn resolve_table_ref(
         &self,
         table_ref: impl Into<TableReference>,
@@ -845,9 +847,9 @@ impl SessionState {
         overwrite: bool,
     ) -> Result<(), DataFusionError> {
         let ext = file_format.get_ext().to_lowercase();
-        match (self.file_formats.entry(ext.clone()), overwrite){
-            (Entry::Vacant(e), _) => {e.insert(file_format);},
-            (Entry::Occupied(mut e), true)  => {e.insert(file_format);},
+        match (self.file_formats.entry(ext.clone()), overwrite) {
+            (Entry::Vacant(e), _) => { e.insert(file_format); }
+            (Entry::Occupied(mut e), true) => { e.insert(file_format); }
             (Entry::Occupied(_), false) => return config_err!("File type already registered for extension {ext}. Set overwrite to true to replace this extension."),
         };
         Ok(())

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -285,7 +285,7 @@ impl SessionState {
             .build()
     }
 
-    pub(crate) fn resolve_table_ref(
+    pub fn resolve_table_ref(
         &self,
         table_ref: impl Into<TableReference>,
     ) -> ResolvedTableReference {


### PR DESCRIPTION
Closes Embucket/control-plane-v2/issues/145

Sql parser version was and now it started to support new ShowSchemas statement instead of ShowVariable 
```sql
SHOW TERSE SCHEMAS IN DATABASE datasets
```
We need to enable information schema for it