### PR TITLE
Fix contraint column name

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1435,7 +1435,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         .map(|u| {
                             let idx = field_names
                                 .iter()
-                                .position(|item| *item == u.value)
+                                .position(|item| *item.to_lowercase() == u.value.to_lowercase())
                                 .ok_or_else(|| {
                                     let name = name
                                         .as_ref()
@@ -1458,7 +1458,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         .map(|pk| {
                             let idx = field_names
                                 .iter()
-                                .position(|item| *item == pk.value)
+                                .position(|item| *item.to_lowercase() == pk.value.to_lowercase())
                                 .ok_or_else(|| {
                                     DataFusionError::Execution(format!(
                                         "Column for primary key not found in schema: {}",


### PR DESCRIPTION
Original issue apache/datafusion#14340

### Describe the bug

Query
```sql
create table test (COLUMN_NAME TEXT NOT NULL,  constraint COLUMN_NAME_PK primary key (COLUMN_NAME))
```
triggers the error 
```Column for primary key not found in schema: COLUMN_NAME```

When creating a table, we build a schema and apply [normalization](https://github.com/apache/datafusion/blob/main/datafusion/sql/src/planner.rs#L260) to column names with to_ascii_lowercase call, which is enabled by default.
But during constraint check we don't do this for the [constraint column name](https://github.com/apache/datafusion/blob/main/datafusion/sql/src/statement.rs#L1459).




### To Reproduce

_No response_

### Expected behavior

The query should work without errors
```sql
create table test (COLUMN_NAME TEXT NOT NULL,  constraint COLUMN_NAME_PK primary key (COLUMN_NAME))
```

### Additional context

Suggestion to use just [to_lowercase](https://github.com/apache/datafusion/blob/main/datafusion/sql/src/statement.rs#L1459) (since we don't pass column names with ascii symbols)
```rust
.position(|item| *item.to_lowercase() == pk.value.to_lowercase())
```