### PR TITLE
Skip CREATE STAGE by DFParser (pass to dialect parser)

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -557,7 +557,8 @@ impl<'a> DFParser<'a> {
             self.parser.expect_keyword(Keyword::EXTERNAL)?;
             self.parse_create_external_table(true)
         } else {
-            Ok(Statement::Statement(Box::from(self.parser.parse_create()?)))
+            self.parser.prev_token();
+            Ok(Statement::Statement(Box::from(self.parser.parse_statement()?)))
         }
     }
 
@@ -930,6 +931,22 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn skip_create_stage_snowflake() -> Result<(), ParserError> {
+        let sql = "CREATE OR REPLACE STAGE stage URL='s3://data.csv' FILE_FORMAT=(TYPE=csv)";
+        let dialect = Box::new(SnowflakeDialect);
+        let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
+
+        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
+        match &statements[0] {
+            Statement::Statement(stmt) => {
+                assert_eq!(stmt.to_string(), sql);
+            }
+            _ => panic!("Expected statement type"),
+        }
+        Ok(())
+    }
     #[test]
     fn create_external_table() -> Result<(), ParserError> {
         // positive case
@@ -1411,18 +1428,19 @@ mod tests {
         assert_eq!(verified_stmt(sql), expected);
         Ok(())
     }
-    
+
     #[test]
     fn skip_copy_into_snowflake() -> Result<(), ParserError> {
-        let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT = (FORMAT_NAME = 'mycsv');";
+        let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT=(FORMAT_NAME='mycsv')";
         let dialect = Box::new(SnowflakeDialect);
         let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
-       
-        assert_eq!( statements.len(), 1, "Expected to parse exactly one statement");
-        if let Statement::CopyTo(_) = &statements[0] {
-            panic!(
-                "Expected non COPY TO statement, but was successful: {statements:?}"
-            );
+
+        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
+        match &statements[0] {
+            Statement::Statement(stmt) => {
+                assert_eq!(stmt.to_string(), sql);
+            }
+            _ => panic!("Expected statement type"),
         }
         Ok(())
     }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -354,6 +354,14 @@ impl<'a> DFParser<'a> {
                         self.parse_create()
                     }
                     Keyword::COPY => {
+                        if let Token::Word(w) = self.parser.peek_nth_token(1).token {
+                            // use native parser for COPY INTO
+                            if w.keyword == Keyword::INTO {
+                                return Ok(Statement::Statement(Box::from(
+                                    self.parser.parse_statement()?,
+                                )));
+                            }
+                        }
                         self.parser.next_token(); // COPY
                         self.parse_copy()
                     }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -889,7 +889,7 @@ mod tests {
     use super::*;
     use sqlparser::ast::Expr::Identifier;
     use sqlparser::ast::{BinaryOperator, DataType, Expr, Ident};
-    use sqlparser::dialect::{SnowflakeDialect};
+    use sqlparser::dialect::SnowflakeDialect;
     use sqlparser::tokenizer::Span;
 
     fn expect_parse_ok(sql: &str, expected: Statement) -> Result<(), ParserError> {

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -559,7 +559,9 @@ impl<'a> DFParser<'a> {
         } else {
             // Push back CREATE
             self.parser.prev_token();
-            Ok(Statement::Statement(Box::from(self.parser.parse_statement()?)))
+            Ok(Statement::Statement(Box::from(
+                self.parser.parse_statement()?,
+            )))
         }
     }
 
@@ -932,14 +934,18 @@ mod tests {
         }
     }
 
-
     #[test]
     fn skip_create_stage_snowflake() -> Result<(), ParserError> {
-        let sql = "CREATE OR REPLACE STAGE stage URL='s3://data.csv' FILE_FORMAT=(TYPE=csv)";
+        let sql =
+            "CREATE OR REPLACE STAGE stage URL='s3://data.csv' FILE_FORMAT=(TYPE=csv)";
         let dialect = Box::new(SnowflakeDialect);
         let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
 
-        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
+        assert_eq!(
+            statements.len(),
+            1,
+            "Expected to parse exactly one statement"
+        );
         match &statements[0] {
             Statement::Statement(stmt) => {
                 assert_eq!(stmt.to_string(), sql);
@@ -1436,7 +1442,11 @@ mod tests {
         let dialect = Box::new(SnowflakeDialect);
         let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
 
-        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
+        assert_eq!(
+            statements.len(),
+            1,
+            "Expected to parse exactly one statement"
+        );
         match &statements[0] {
             Statement::Statement(stmt) => {
                 assert_eq!(stmt.to_string(), sql);

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -889,7 +889,7 @@ mod tests {
     use super::*;
     use sqlparser::ast::Expr::Identifier;
     use sqlparser::ast::{BinaryOperator, DataType, Expr, Ident};
-    use sqlparser::dialect::{dialect_from_str, SnowflakeDialect};
+    use sqlparser::dialect::{SnowflakeDialect};
     use sqlparser::tokenizer::Span;
 
     fn expect_parse_ok(sql: &str, expected: Statement) -> Result<(), ParserError> {

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -557,6 +557,7 @@ impl<'a> DFParser<'a> {
             self.parser.expect_keyword(Keyword::EXTERNAL)?;
             self.parse_create_external_table(true)
         } else {
+            // Push back CREATE
             self.parser.prev_token();
             Ok(Statement::Statement(Box::from(self.parser.parse_statement()?)))
         }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -1411,8 +1411,7 @@ mod tests {
         assert_eq!(verified_stmt(sql), expected);
         Ok(())
     }
-
-
+    
     #[test]
     fn skip_copy_into_snowflake() -> Result<(), ParserError> {
         let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT = (FORMAT_NAME = 'mycsv');";
@@ -1427,7 +1426,6 @@ mod tests {
         }
         Ok(())
     }
-
 
     #[test]
     fn explain_copy_to_table_to_table() -> Result<(), ParserError> {


### PR DESCRIPTION
Related to Embucket/control-plane-v2#178

In case the statement is not CREATE EXTERNAL, try to use selected dialect parser to parse statements like "CREATE STAGE" which a not supported by default, but supported by SnowflakeDialect for example.