### PR TITLE
Add e flag support

### DIFF
--- a/datafusion/functions/src/regex/regexpsubstr.rs
+++ b/datafusion/functions/src/regex/regexpsubstr.rs
@@ -229,7 +229,7 @@ fn regexp_substr_inner<T: OffsetSizeTrait>(
     };
 
     // Check for 'e' flag and set group_num to 1 if not provided
-    let group_num = if flags.map_or(false, |f| f.contains('e')) {
+    let group_num = if flags.is_some_and(|f| f.contains('e')) {
         group_num.or(Some(1))
     } else {
         group_num

--- a/datafusion/functions/src/regex/regexpsubstr.rs
+++ b/datafusion/functions/src/regex/regexpsubstr.rs
@@ -227,6 +227,14 @@ fn regexp_substr_inner<T: OffsetSizeTrait>(
         }
         Some(regex) => regex,
     };
+
+    // Check for 'e' flag and set group_num to 1 if not provided
+    let group_num = if flags.map_or(false, |f| f.contains('e')) {
+        group_num.or(Some(1))
+    } else {
+        group_num
+    };
+
     let regex = compile_regex(regex, flags)?;
     let mut builder = GenericStringBuilder::<T>::new();
 
@@ -247,7 +255,6 @@ fn regexp_substr_inner<T: OffsetSizeTrait>(
 
                 let matches =
                     get_matches(cleaned_value.as_str(), &regex, occurrence, group_num);
-
                 if matches.is_empty() {
                     builder.append_null();
                 } else {
@@ -274,6 +281,7 @@ fn get_matches(
     let occurrence = occurrence.unwrap_or(1) as usize;
 
     for caps in regex.captures_iter(value) {
+        println!("{value}  caps {:?}", caps);
         match group_num {
             Some(group_num) => {
                 if let Some(m) = caps.get(group_num as usize) {
@@ -307,8 +315,12 @@ fn compile_regex(regex: &str, flags: Option<&str>) -> Result<Regex, ArrowError> 
                 ));
             }
             // Case-sensitive enabled by default
-            let flags = flags.replace("c", "");
-            format!("(?{}){}", flags, regex)
+            let flags = flags.replace("c", "").replace("e", "");
+            if flags.is_empty() {
+                regex.to_string()
+            } else {
+                format!("(?{}){}", flags, regex)
+            }
         }
     };
 
@@ -469,66 +481,71 @@ mod tests {
     fn test_regexp_substr_with_params() {
         let values = [
             "",
-            "aabca aabca",
-            "abc abc",
-            "Abcab abc",
-            "abCab cabc",
-            "ab",
+            "aabc aabca vff ddf",
+            "abc abca abcD vff",
+            "Abcab abcD caddd",
+            "abCab cabcd dasaaabc VfFddd",
+            "ab dasacabd caBcv dasaaabcdv",
         ];
-        let regex = "abc";
-        let position = 1;
-        let occurrence = 1;
-        let flags = "i";
-        let group_num = 0;
-        let expected = ["", "abc", "abc", "Abc", "abC", ""];
+        let regex = ["abc", "(abc\\S)|(bca)", "(abc)|(bca)", "(abc)|(vff)|(d)"];
+        let flags = ["i", "ie", "e", "i"];
+        let group_num = [0, 1, 0, 2];
+        let expected = [
+            ["", "abc", "abc", "Abc", "abC", "aBc"],
+            ["", "abca", "abca", "Abca", "abCa", "aBcv"],
+            ["", "abc", "abc", "bca", "abc", "abc"],
+            ["", "vff", "vff", "", "VfF", ""]
+        ];
 
         // Scalar
-        values.iter().enumerate().for_each(|(pos, &value)| {
-            let expected = expected.get(pos).cloned().unwrap();
-            // Utf8, LargeUtf8
-            for (data_type, scalar) in &[
-                (
-                    DataType::Utf8,
-                    ScalarValue::Utf8 as fn(Option<String>) -> ScalarValue,
-                ),
-                (
-                    DataType::LargeUtf8,
-                    ScalarValue::LargeUtf8 as fn(Option<String>) -> ScalarValue,
-                ),
-            ] {
-                let result =
-                    RegexpSubstrFunc::new().invoke_with_args(ScalarFunctionArgs {
-                        args: vec![
-                            ColumnarValue::Scalar(scalar(Some(value.to_string()))),
-                            ColumnarValue::Scalar(scalar(Some(regex.to_string()))),
-                            ColumnarValue::Scalar(ScalarValue::Int64(Some(position))),
-                            ColumnarValue::Scalar(ScalarValue::Int64(Some(occurrence))),
-                            ColumnarValue::Scalar(scalar(Some(flags.to_string()))),
-                            ColumnarValue::Scalar(ScalarValue::Int64(Some(group_num))),
-                        ],
-                        number_rows: 1,
-                        return_type: data_type,
-                    });
-                match result {
-                    Ok(ColumnarValue::Scalar(
-                        ScalarValue::Utf8(ref res) | ScalarValue::LargeUtf8(ref res),
-                    )) => {
-                        if res.is_some() {
-                            assert_eq!(
-                                res.as_ref().unwrap(),
-                                &expected.to_string(),
-                                "regexp_substr scalar test failed"
-                            );
-                        } else {
-                            assert_eq!(
-                                "", expected,
-                                "regexp_substr scalar utf8 test failed"
-                            )
+        regex.iter().enumerate().for_each(|(spos, &regex)| {
+            values.iter().enumerate().for_each(|(pos, &value)| {
+                let expected = expected.get(spos).unwrap().get(pos).cloned().unwrap();
+                // Utf8, LargeUtf8
+                for (data_type, scalar) in &[
+                    (
+                        DataType::Utf8,
+                        ScalarValue::Utf8 as fn(Option<String>) -> ScalarValue,
+                    ),
+                    (
+                        DataType::LargeUtf8,
+                        ScalarValue::LargeUtf8 as fn(Option<String>) -> ScalarValue,
+                    ),
+                ] {
+                    let result =
+                        RegexpSubstrFunc::new().invoke_with_args(ScalarFunctionArgs {
+                            args: vec![
+                                ColumnarValue::Scalar(scalar(Some(value.to_string()))),
+                                ColumnarValue::Scalar(scalar(Some(regex.to_string()))),
+                                ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
+                                ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
+                                ColumnarValue::Scalar(scalar(Some(flags[spos].to_string()))),
+                                ColumnarValue::Scalar(ScalarValue::Int64(Some(group_num[spos]))),
+                            ],
+                            number_rows: 1,
+                            return_type: data_type,
+                        });
+                    match result {
+                        Ok(ColumnarValue::Scalar(
+                               ScalarValue::Utf8(ref res) | ScalarValue::LargeUtf8(ref res),
+                           )) => {
+                            if res.is_some() {
+                                assert_eq!(
+                                    res.as_ref().unwrap(),
+                                    &expected.to_string(),
+                                    "regexp_substr scalar test failed"
+                                );
+                            } else {
+                                assert_eq!(
+                                    "", expected,
+                                    "regexp_substr scalar utf8 test failed"
+                                )
+                            }
                         }
+                        _ => panic!("Unexpected result"),
                     }
-                    _ => panic!("Unexpected result"),
                 }
-            }
+            })
         });
     }
 

--- a/datafusion/functions/src/regex/regexpsubstr.rs
+++ b/datafusion/functions/src/regex/regexpsubstr.rs
@@ -281,7 +281,6 @@ fn get_matches(
     let occurrence = occurrence.unwrap_or(1) as usize;
 
     for caps in regex.captures_iter(value) {
-        println!("{value}  caps {:?}", caps);
         match group_num {
             Some(group_num) => {
                 if let Some(m) = caps.get(group_num as usize) {

--- a/datafusion/functions/src/regex/regexpsubstr.rs
+++ b/datafusion/functions/src/regex/regexpsubstr.rs
@@ -493,7 +493,7 @@ mod tests {
             ["", "abc", "abc", "Abc", "abC", "aBc"],
             ["", "abca", "abca", "Abca", "abCa", "aBcv"],
             ["", "abc", "abc", "bca", "abc", "abc"],
-            ["", "vff", "vff", "", "VfF", ""]
+            ["", "vff", "vff", "", "VfF", ""],
         ];
 
         // Scalar
@@ -518,16 +518,20 @@ mod tests {
                                 ColumnarValue::Scalar(scalar(Some(regex.to_string()))),
                                 ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
                                 ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
-                                ColumnarValue::Scalar(scalar(Some(flags[spos].to_string()))),
-                                ColumnarValue::Scalar(ScalarValue::Int64(Some(group_num[spos]))),
+                                ColumnarValue::Scalar(scalar(Some(
+                                    flags[spos].to_string(),
+                                ))),
+                                ColumnarValue::Scalar(ScalarValue::Int64(Some(
+                                    group_num[spos],
+                                ))),
                             ],
                             number_rows: 1,
                             return_type: data_type,
                         });
                     match result {
                         Ok(ColumnarValue::Scalar(
-                               ScalarValue::Utf8(ref res) | ScalarValue::LargeUtf8(ref res),
-                           )) => {
+                            ScalarValue::Utf8(ref res) | ScalarValue::LargeUtf8(ref res),
+                        )) => {
                             if res.is_some() {
                                 assert_eq!(
                                     res.as_ref().unwrap(),


### PR DESCRIPTION
Fixed missing logic for **e** flag
https://docs.snowflake.com/en/sql-reference/functions/regexp_substr

> By default, REGEXP_SUBSTR returns the entire matching part of the subject. However, if the e (for “extract”) parameter is specified, REGEXP_SUBSTR returns the part of the subject that matches the first group in the pattern. If e is specified but a group_num is not also specified, then the group_num defaults to 1 (the first group). If there is no sub-expression in the pattern, REGEXP_SUBSTR behaves as if e was not set.
