### PR TITLE
arrow format support

### DIFF
--- a/datafusion/core/tests/user_defined/insert_operation.rs
+++ b/datafusion/core/tests/user_defined/insert_operation.rs
@@ -184,7 +184,7 @@ impl ExecutionPlan for TestInsertExec {
 fn make_count_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![Field::new(
         "count",
-        DataType::UInt64,
+        DataType::Int64, // should return signed int for snowflake
         false,
     )]))
 }

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -203,7 +203,8 @@ impl Display for InsertOp {
 
 fn make_count_schema() -> DFSchemaRef {
     Arc::new(
-        Schema::new(vec![Field::new("count", DataType::UInt64, false)])
+        // should return signed int for snowflake
+        Schema::new(vec![Field::new("count", DataType::Int64, false)])
             .try_into()
             .unwrap(),
     )

--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -32,7 +32,7 @@ use crate::ExecutionPlanProperties;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use arrow_array::{ArrayRef, UInt64Array};
+use arrow_array::{ArrayRef, Int64Array};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::TaskContext;
@@ -261,7 +261,7 @@ impl ExecutionPlan for DataSinkExec {
 /// +-------+,
 /// ```
 fn make_count_batch(count: u64) -> RecordBatch {
-    let array = Arc::new(UInt64Array::from(vec![count])) as ArrayRef;
+    let array = Arc::new(Int64Array::from(vec![count as i64])) as ArrayRef;
 
     RecordBatch::try_from_iter_with_nullable(vec![("count", array, false)]).unwrap()
 }
@@ -270,7 +270,7 @@ fn make_count_schema() -> SchemaRef {
     // Define a schema.
     Arc::new(Schema::new(vec![Field::new(
         "count",
-        DataType::UInt64,
+        DataType::Int64, // should return signed int for snowflake
         false,
     )]))
 }


### PR DESCRIPTION
Related to issue https://github.com/Embucket/control-plane-v2/issues/115
Main PR : https://github.com/Embucket/control-plane-v2/pull/222

Hash commit of change in datafusion propagated in repos too:
https://github.com/Embucket/datafusion-functions-json/pull/4
https://github.com/Embucket/iceberg-rust/pull/14

To support arrow format for RecordBatch,  UInt64 datatype replaced by Int64 in count batch of output schema.