### PR TITLE
Revert commit: 314a726

### DIFF
--- a/datafusion/core/tests/user_defined/insert_operation.rs
+++ b/datafusion/core/tests/user_defined/insert_operation.rs
@@ -184,7 +184,7 @@ impl ExecutionPlan for TestInsertExec {
 fn make_count_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![Field::new(
         "count",
-        DataType::Int64, // should return signed int for snowflake
+        DataType::UInt64,
         false,
     )]))
 }

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -203,8 +203,7 @@ impl Display for InsertOp {
 
 fn make_count_schema() -> DFSchemaRef {
     Arc::new(
-        // should return signed int for snowflake
-        Schema::new(vec![Field::new("count", DataType::Int64, false)])
+        Schema::new(vec![Field::new("count", DataType::UInt64, false)])
             .try_into()
             .unwrap(),
     )

--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -272,7 +272,6 @@ impl ExecutionPlan for DataSinkExec {
 /// ```
 fn make_count_batch(count: u64) -> RecordBatch {
     let array = Arc::new(Int64Array::from(vec![count as i64])) as ArrayRef;
-    println!("array: {array:?}");
     RecordBatch::try_from_iter_with_nullable(vec![("count", array, false)]).unwrap()
 }
 

--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -32,7 +32,7 @@ use crate::ExecutionPlanProperties;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use arrow_array::{ArrayRef, Int64Array};
+use arrow_array::{ArrayRef, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::TaskContext;
@@ -271,7 +271,8 @@ impl ExecutionPlan for DataSinkExec {
 /// +-------+,
 /// ```
 fn make_count_batch(count: u64) -> RecordBatch {
-    let array = Arc::new(Int64Array::from(vec![count as i64])) as ArrayRef;
+    let array = Arc::new(UInt64Array::from(vec![count])) as ArrayRef;
+
     RecordBatch::try_from_iter_with_nullable(vec![("count", array, false)]).unwrap()
 }
 
@@ -279,7 +280,7 @@ fn make_count_schema() -> SchemaRef {
     // Define a schema.
     Arc::new(Schema::new(vec![Field::new(
         "count",
-        DataType::Int64, // should return signed int for snowflake
+        DataType::UInt64,
         false,
     )]))
 }


### PR DESCRIPTION
Re-purpose this PR: Revert commit: 314a72634dc4f15242345fd17dc32df6c3ae04e8

PR in rust-iceberg repo fixes "return affected rows count for insert statements"
