### PR TITLE
information schema tables, columns, schemas, views per specific catalog

### DIFF
--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -20,7 +20,7 @@
 //! [Information Schema]: https://en.wikipedia.org/wiki/Information_schema
 
 use crate::streaming::StreamingTable;
-use crate::{CatalogProvider, CatalogProviderList, SchemaProvider, TableProvider};
+use crate::{CatalogProviderList, SchemaProvider, TableProvider};
 use arrow::array::builder::{BooleanBuilder, UInt8Builder};
 use arrow::{
     array::{StringBuilder, UInt64Builder},

--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -74,9 +74,15 @@ pub struct InformationSchemaProvider {
 
 impl InformationSchemaProvider {
     /// Creates a new [`InformationSchemaProvider`] for the provided `catalog_list`
-    pub fn new(catalog_list: Arc<dyn CatalogProviderList>, catalog_name: Arc<str>) -> Self {
+    pub fn new(
+        catalog_list: Arc<dyn CatalogProviderList>,
+        catalog_name: Arc<str>,
+    ) -> Self {
         Self {
-            config: InformationSchemaConfig { catalog_list, catalog_name },
+            config: InformationSchemaConfig {
+                catalog_list,
+                catalog_name,
+            },
         }
     }
 }
@@ -84,7 +90,7 @@ impl InformationSchemaProvider {
 #[derive(Clone, Debug)]
 struct InformationSchemaConfig {
     catalog_list: Arc<dyn CatalogProviderList>,
-    catalog_name: Arc<str>
+    catalog_name: Arc<str>,
 }
 
 impl InformationSchemaConfig {
@@ -96,7 +102,7 @@ impl InformationSchemaConfig {
         let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
             return Ok(());
         };
-        
+
         // create a mem table with the names of tables
         for schema_name in catalog.schema_names() {
             if schema_name != INFORMATION_SCHEMA {
@@ -131,9 +137,9 @@ impl InformationSchemaConfig {
 
     async fn make_schemata(&self, builder: &mut InformationSchemataBuilder) {
         let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
-            return
+            return;
         };
-        
+
         for schema_name in catalog.schema_names() {
             if schema_name != INFORMATION_SCHEMA {
                 if let Some(schema) = catalog.schema(&schema_name) {
@@ -151,7 +157,7 @@ impl InformationSchemaConfig {
         let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
             return Ok(());
         };
-        
+
         for schema_name in catalog.schema_names() {
             if schema_name != INFORMATION_SCHEMA {
                 // schema name may not exist in the catalog, so we need to check
@@ -180,7 +186,7 @@ impl InformationSchemaConfig {
         let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
             return Ok(());
         };
-        
+
         for schema_name in catalog.schema_names() {
             if schema_name != INFORMATION_SCHEMA {
                 // schema name may not exist in the catalog, so we need to check

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -306,9 +306,10 @@ impl SessionState {
         let resolved_ref = self.resolve_table_ref(table_ref);
         if self.config.information_schema() && *resolved_ref.schema == *INFORMATION_SCHEMA
         {
-            return Ok(Arc::new(InformationSchemaProvider::new(Arc::clone(
-                &self.catalog_list,
-            ))));
+            return Ok(Arc::new(InformationSchemaProvider::new(
+                Arc::clone(&self.catalog_list),
+                resolved_ref.catalog,
+            )));
         }
 
         self.catalog_list


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/15960
- Closes https://github.com/Embucket/embucket/issues/701

## Rationale for this change

According to [Postgres docs](https://www.postgresql.org/docs/current/infoschema-tables.html) information_schema.tables should contain all tables and views defined in the **current database**, not from all catalogs
The same for columns, schemas, views

## What changes are included in this PR?

Use resolved table reference to get catalog name and pass it to InformationSchemaProvider builder to fetch tables for only this particular catalog instead of all catalogs

## Are these changes tested?

Tested localy

## Are there any user-facing changes?

No