### PR TITLE
Enhance string concat coercion to support castable types 

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1151,7 +1151,14 @@ fn string_concat_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
         (Dictionary(_, lhs_value_type), Dictionary(_, rhs_value_type)) => {
             string_coercion(lhs_value_type, rhs_value_type).or(None)
         }
-        _ => None,
+        _ =>
+            if can_cast_types(lhs_type, &Utf8) && can_cast_types(rhs_type, &Utf8) {
+                Some(Utf8)
+            } else if can_cast_types(lhs_type, &LargeUtf8) && can_cast_types(rhs_type, &LargeUtf8) {
+                Some(LargeUtf8)
+            } else {
+                None
+            }
     })
 }
 

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1151,14 +1151,17 @@ fn string_concat_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
         (Dictionary(_, lhs_value_type), Dictionary(_, rhs_value_type)) => {
             string_coercion(lhs_value_type, rhs_value_type).or(None)
         }
-        _ =>
+        _ => {
             if can_cast_types(lhs_type, &Utf8) && can_cast_types(rhs_type, &Utf8) {
                 Some(Utf8)
-            } else if can_cast_types(lhs_type, &LargeUtf8) && can_cast_types(rhs_type, &LargeUtf8) {
+            } else if can_cast_types(lhs_type, &LargeUtf8)
+                && can_cast_types(rhs_type, &LargeUtf8)
+            {
                 Some(LargeUtf8)
             } else {
                 None
             }
+        }
     })
 }
 


### PR DESCRIPTION
Related to https://github.com/Embucket/embucket/issues/1155
Related to https://github.com/apache/datafusion/issues/16510
This allows
```sql
select 1||2;
+----------------------+
| Int64(1) || Int64(2) |
|----------------------|
| 12                   |
+----------------------+

select 1::decimal(10)||2::decimal(10);
+--------------------------------+
| 1::DECIMAL(10)||2::DECIMAL(10) |
|--------------------------------|
| 12                             |
+--------------------------------+

```
Any 