### PR TITLE
Added basic support for table functions in relations

### DIFF
--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -118,10 +118,6 @@ pub fn create_physical_expr(
             let idx = input_dfschema.index_of_column(c)?;
             Ok(Arc::new(Column::new(&c.name, idx)))
         }
-        Expr::OuterReferenceColumn(_datatype, c) => {
-            let idx = input_dfschema.index_of_column(c)?;
-            Ok(Arc::new(Column::new(&c.name, idx)))
-        }
         Expr::Literal(value) => Ok(Arc::new(Literal::new(value.clone()))),
         Expr::ScalarVariable(_, variable_names) => {
             if is_system_variables(variable_names) {

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -403,7 +403,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             TableFactor::Function {
                 name, args, alias, ..
             } => {
-                let tbl_func_name = self.object_name_to_table_reference(name)?;
+                let tbl_func_ref = self.object_name_to_table_reference(name)?;
                 let schema = planner_context
                     .outer_query_schema()
                     .cloned()
@@ -434,10 +434,10 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         _ => plan_err!("Unsupported function argument: {arg:?}"),
                     })
                     .collect::<Result<Vec<(Expr, Option<String>)>>>()?;
-
+                let tbl_func_name = tbl_func_ref.table().to_ascii_lowercase();
                 let provider = self
                     .context_provider
-                    .get_table_function_source(tbl_func_name.table(), func_args)?;
+                    .get_table_function_source(&tbl_func_name, func_args)?;
                 let plan =
                     LogicalPlanBuilder::scan(tbl_func_name, provider, None)?.build()?;
                 (plan, alias)


### PR DESCRIPTION
## Rationale for this change

Related to https://github.com/Embucket/embucket/issues/781

## What changes are included in this PR?

Added support for TableFactor::Function in relation for statements like
```sql
SELECT 
  jsontext
FROM  test
INNER JOIN LATERAL  flatten(INPUT => PARSE_JSON('{"key": "value"}')) d
```
The problem with outer colums in table functions join still exist.